### PR TITLE
RWD.Toolbox.Logging - Update to Latest Version of .NET

### DIFF
--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ master ]
 env:
-  DOTNET_VERSION: '6.0.401' # The .NET SDK version to use
+  DOTNET_VERSION: '10.0.x' # The .NET SDK version to use
 jobs:
   generate-docs:
     runs-on: windows-latest

--- a/RWD.Toolbox.Logging.Demo.ClassLibrary/RWD.Toolbox.Logging.Demo.ClassLibrary.csproj
+++ b/RWD.Toolbox.Logging.Demo.ClassLibrary/RWD.Toolbox.Logging.Demo.ClassLibrary.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/RWD.Toolbox.Logging.Demo.Communication/RWD.Toolbox.Logging.Demo.Communication.csproj
+++ b/RWD.Toolbox.Logging.Demo.Communication/RWD.Toolbox.Logging.Demo.Communication.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/RWD.Toolbox.Logging.Demo.Console/RWD.Toolbox.Logging.Demo.Console.csproj
+++ b/RWD.Toolbox.Logging.Demo.Console/RWD.Toolbox.Logging.Demo.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
 	<ItemGroup>
@@ -16,11 +16,11 @@
 	</ItemGroup>	  
 
   <ItemGroup>
-    <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
-    <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.7.1" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
+    <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="9.0.2" />
   </ItemGroup>
 
 </Project>

--- a/RWD.Toolbox.Logging.Demo.MVC/Controllers/HomeController.cs
+++ b/RWD.Toolbox.Logging.Demo.MVC/Controllers/HomeController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using RWD.Toolbox.Logging.Demo.Communication;
 using RWD.Toolbox.Logging.Demo.MVC.Models;
@@ -13,12 +14,15 @@ namespace RWD.Toolbox.Logging.Demo.MVC.Controllers
     {
         private readonly ILogger<HomeController> _logger;
         private readonly ICommunicationAgent _commAgent;
-
+        private readonly IConfiguration _configuration;
+        private readonly string _apiBaseUrl;
         
-        public HomeController(ICommunicationAgent commAgent, ILogger<HomeController> logger)
+        public HomeController(ICommunicationAgent commAgent, ILogger<HomeController> logger, IConfiguration configuration)
         {
             _logger = logger;
             _commAgent = commAgent;
+            _configuration = configuration;
+            _apiBaseUrl = _configuration.GetSection("ApiSettings").GetValue<string>("BaseUrl");
         }
 
         // Track Usage via Attribute
@@ -26,7 +30,7 @@ namespace RWD.Toolbox.Logging.Demo.MVC.Controllers
         public async Task<IActionResult> Index()
         {
             var model = new WeatherForecasts();
-            var f = await _commAgent.GetListFromApiAsync<WeatherForecast>("https://localhost:44310/api/data/weather", HttpContext, _logger);
+            var f = await _commAgent.GetListFromApiAsync<WeatherForecast>($"{_apiBaseUrl}/api/data/weather", HttpContext, _logger);
             model.Forecasts.AddRange(f);
 
             // example of manual log
@@ -41,14 +45,14 @@ namespace RWD.Toolbox.Logging.Demo.MVC.Controllers
         [TypeFilter(typeof(TrackPerformanceAttribute))]
         public async Task<IActionResult> PageTwo()
         {
-            var dataList = await _commAgent.GetListFromApiAsync<ToDoItem>("https://localhost:44310/api/data/todos", HttpContext, _logger);
+            var dataList = await _commAgent.GetListFromApiAsync<ToDoItem>($"{_apiBaseUrl}/api/data/todos", HttpContext, _logger);
             return View();
         }
 
         // Example of Error coming from Web API Call
         public async Task<IActionResult> PageTwoError()
         {
-            var dataList = await _commAgent.GetListFromApiAsync<ToDoItem>("https://localhost:44310/api/data/error", HttpContext, _logger);
+            var dataList = await _commAgent.GetListFromApiAsync<ToDoItem>($"{_apiBaseUrl}/api/data/error", HttpContext, _logger);
             return View("Index");
         }
 

--- a/RWD.Toolbox.Logging.Demo.MVC/RWD.Toolbox.Logging.Demo.MVC.csproj
+++ b/RWD.Toolbox.Logging.Demo.MVC/RWD.Toolbox.Logging.Demo.MVC.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <CopyRefAssembliesToPublishDirectory>false</CopyRefAssembliesToPublishDirectory>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.8" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Enrichers.AspnetcoreHttpcontext" Version="1.1.0" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RWD.Toolbox.Logging.Demo.MVC/appsettings.json
+++ b/RWD.Toolbox.Logging.Demo.MVC/appsettings.json
@@ -25,5 +25,8 @@
     ],
     "Enrich": [ "FromLogContext", "WithMachineName", "WithExceptionDetails", "WithEnvironmentName", "WithEnvironmentUserName" ]
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ApiSettings": {
+    "BaseUrl": "https://localhost:59996"
+  }
 }

--- a/RWD.Toolbox.Logging.Demo.WebAPI/Program.cs
+++ b/RWD.Toolbox.Logging.Demo.WebAPI/Program.cs
@@ -8,10 +8,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using RWD.Toolbox.Logging.Demo.ClassLibrary;
 using RWD.Toolbox.Logging.Infrastructure.Filters;
-using Microsoft.OpenApi.Models;
 using RWD.Toolbox.Logging.Infrastructure.Middleware;
 using Microsoft.AspNetCore.Http;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
+using Microsoft.OpenApi;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/RWD.Toolbox.Logging.Demo.WebAPI/RWD.Toolbox.Logging.Demo.WebAPI.csproj
+++ b/RWD.Toolbox.Logging.Demo.WebAPI/RWD.Toolbox.Logging.Demo.WebAPI.csproj
@@ -1,19 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Enrichers.AspnetcoreHttpcontext" Version="1.1.0" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.4.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RWD.Toolbox.Logging.Infrastructure/RWD.Toolbox.Logging.Infrastructure.csproj
+++ b/RWD.Toolbox.Logging.Infrastructure/RWD.Toolbox.Logging.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>RealWorldDevelopers</Authors>
     <Description>A Free .NET Library to assist with writing logs.</Description>
@@ -32,8 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.9" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/RWD.Toolbox.Logging/RWD.Toolbox.Logging.Demo.Static.csproj
+++ b/RWD.Toolbox.Logging/RWD.Toolbox.Logging.Demo.Static.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,13 +9,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Enrichers.AspnetcoreHttpcontext" Version="1.1.0" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
-    <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.7.1" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="9.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR should address the following open issuse: #6

Changes:
- All projects should now be targeting .NET 10
- `docfx.yml` should be configured to use .NET 10 as the `DOTNET_VERSION`
- Updated packages and fixed any breaking changes that may have been introduced as a result of this
- `System.Data.SqlClient` is deprecated and has been replaced with `Microsoft.Data.SqlClient`

Testing:
- Tested the `Index` and `PageTwo` endpoints in the `HomeController` since they track usage/performance with the `TrackUsageAttribute` and `TrackPerformanceAttribute` respectively. Debugged through the implementation in the `Infrastructure` class library to ensure proper logging still occurred.